### PR TITLE
style: hide horizontal info section on desktop for improved layout

### DIFF
--- a/assets/css/desktop.css
+++ b/assets/css/desktop.css
@@ -4,6 +4,11 @@
 @media (min-width: 769px) and (orientation: portrait),
 (min-width: 1025px) {
 
+    /* Hide the horizontal info section in desktop - only show main about section */
+    #info-horizontal {
+        display: none !important;
+    }
+
     /* Hide the contact link completely on desktop */
     #contact-link {
         display: none;


### PR DESCRIPTION
- Added CSS rule to hide the horizontal info section on desktop devices, ensuring only the main about section is displayed for a cleaner interface.